### PR TITLE
Replace hardcoded year with dynamic value

### DIFF
--- a/sites/dashboard/index.ejs
+++ b/sites/dashboard/index.ejs
@@ -45,7 +45,7 @@
     } 
 
     fetch(
-      '<%=APIRootURL%>/<%=APIStageName%>/ranking?website=<%=WebsiteID%>&date=YEAR:2017'
+      `<%=APIRootURL%>/<%=APIStageName%>/ranking?website=<%=WebsiteID%>&date=YEAR:${(new Date()).getFullYear()}`
     ).then(
       res => res.json()
     ).then(


### PR DESCRIPTION
Currently with new deployment analytics dashboard is empty. This might be confusing and look like analytics are not working. This change removes hardcoded year 2017 and replaces it with dynamic "current year" value. 